### PR TITLE
Add MATLAB Tests CI and fix double free problem in update

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -1,0 +1,110 @@
+name: MATLAB Tests CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
+
+jobs:
+  build-matlab-tests:    
+    name: '[matlab:${{ matrix.matlab_version }}:${{ matrix.os }}]'
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Release]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        matlab_version: [R2020a, R2020b, R2021a, latest]
+        exclude:
+          # R2020* is not supported on Windows on GitHub Actions
+          - os: windows-2019
+            matlab_version: R2020a
+            build_type: Release
+          - os: windows-2019
+            matlab_version: R2020b
+            build_type: Release
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: conda-incubator/setup-miniconda@v2
+      with:
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        channels: conda-forge,robotology
+
+    - name: Setup MATLAB
+      uses: matlab-actions/setup-matlab@v1
+      with:
+        release: ${{ matrix.matlab_version }}
+
+    # workaround for https://github.com/robotology/robotology-superbuild/issues/64
+    - name: Do not use MATLAB's stdc++ to avoid incompatibilities with other libraries
+      if: contains(matrix.os, 'ubuntu')
+      run:
+          echo 'LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6' >> $GITHUB_ENV
+
+    - name: Dependencies
+      run: |
+        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
+        conda config --remove channels defaults
+        # Compilation related dependencies 
+        mamba install cmake compilers make ninja pkg-config
+        # Actual dependencies
+        mamba install osqp
+        # Just a trick to make sure that the relevant installation path are on MATLABPATH
+        mamba install -c conda-forge -c robotology idyntree-matlab-bindings
+
+    # Additional dependencies useful only on Windows
+    - name: Dependencies [Conda/Windows]
+      if: contains(matrix.os, 'windows') 
+      run: |
+        # Additional dependencies only useful on Windows
+        # See https://github.com/robotology/robotology-superbuild/issues/477
+        mamba install vs2019_win-64
+
+    - name: Print used environment [Conda]
+      shell: bash -l {0}
+      run: |
+        mamba list
+        env
+
+    - name: Configure [Conda - Linux or  macOS]
+      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+      run: |
+        mkdir build
+        cd build
+        cmake -GNinja -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTING:BOOL=ON ..
+
+    - name: Configure [Conda - Windows]
+      if: contains(matrix.os, 'windows')
+      run: |
+        mkdir build
+        cd build
+        cmake  -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_TESTING:BOOL=ON ..
+
+    - name: Build
+      run: |
+        cd build
+        cmake --build . --config ${{ matrix.build_type }}
+
+    - name: Install
+      run: |
+        cd build
+        cmake --install . --config ${{ matrix.build_type }}
+
+    - name: Test
+      run: |
+        cd build
+        ctest --output-on-failure -C ${{ matrix.build_type }} -VV . 
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.16)
 
 set(OSQP_MATLAB_UPSTREAM_VERSION 0.6.2)
-set(OSQP_MATLAB_CMAKE_REVISION 1)
+set(OSQP_MATLAB_CMAKE_REVISION 2)
 set(OSQP_MATLAB_CMAKE_VERSION "${OSQP_MATLAB_UPSTREAM_VERSION}.${OSQP_MATLAB_CMAKE_REVISION}")
 project(osqp-matlab-cmake-buildsystem
   LANGUAGES C CXX
@@ -65,7 +65,7 @@ FetchContent_Declare(
   osqp-matlab
   GIT_REPOSITORY https://github.com/traversaro/osqp-matlab
 # GIT_TAG        v${OSQP_MATLAB_UPSTREAM_VERSION}
-  GIT_TAG        aff21017e4396aed8cf7537a14fe540ae5b0c374
+  GIT_TAG        09faf01f42f7a73fac0b03332e6b0f6976a943c8
   )
 
 FetchContent_MakeAvailable(osqp-matlab)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
 option(OSQP_MATLAB_USES_MATLAB "Do you want to create the MATLAB bindings" ON)
 option(OSQP_MATLAB_USES_OCTAVE "Do you want to create the Octave bindings" OFF)
 
+option(BUILD_TESTING "Create tests using CMake" OFF)
+if(BUILD_TESTING)
+  enable_testing()
+endif()
+
 set(OSQP_MATLAB_INSTALL_MATLAB_LIBDIR "mex" CACHE
     STRING "Location (relative to the install prefix) in which the Matlab mex libraries are installed.")
 set(OSQP_MATLAB_INSTALL_MATLAB_MFILESDIR "mex" CACHE
@@ -73,7 +78,8 @@ set(M_FILES ${osqp-matlab_SOURCE_DIR}/osqp.m)
 set(MEX_FILES ${osqp-matlab_SOURCE_DIR}/osqp_mex.hpp ${osqp-matlab_SOURCE_DIR}/osqp_mex.cpp)
 
 if(OSQP_MATLAB_USES_MATLAB)
-  find_package(Matlab REQUIRED)
+  find_package(Matlab REQUIRED
+               COMPONENTS MAIN_PROGRAM)
   matlab_add_mex(
       NAME osqp_mex_matlab
       OUTPUT_NAME osqp_mex
@@ -89,6 +95,15 @@ if(OSQP_MATLAB_USES_MATLAB)
   install(
     FILES ${M_FILES}
     DESTINATION ${OSQP_MATLAB_INSTALL_MATLAB_MFILESDIR})
+
+    # Enable tests
+    if (BUILD_TESTING)
+      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/run_osqp_tests_no_codegen.m.in ${CMAKE_CURRENT_BINARY_DIR}/run_osqp_tests_no_codegen.m @ONLY)
+      # Note: this only works if the project was installed in the correct location and can be found with MATLABPATH
+      add_test(NAME matlab_osqp_tests
+           COMMAND ${Matlab_MAIN_PROGRAM} -nodisplay -nodesktop -nojvm -batch "addpath('${CMAKE_CURRENT_BINARY_DIR}');run_osqp_tests_no_codegen;")
+
+    endif()
 endif()
 
 if(OSQP_MATLAB_USES_OCTAVE)
@@ -115,5 +130,6 @@ if(OSQP_MATLAB_USES_OCTAVE)
     FILES ${M_FILES}
     DESTINATION ${OSQP_MATLAB_INSTALL_OCTAVE_MFILESDIR})
 endif()
+
 
 include(AddUninstallTarget)

--- a/run_osqp_tests_no_codegen.m.in
+++ b/run_osqp_tests_no_codegen.m.in
@@ -1,0 +1,22 @@
+import matlab.unittest.TestSuite;
+import matlab.unittest.selectors.HasSharedTestFixture;
+import matlab.unittest.selectors.HasName;
+import matlab.unittest.fixtures.PathFixture;
+import matlab.unittest.constraints.EndsWithSubstring;
+import matlab.unittest.constraints.ContainsSubstring;
+
+osqp_src_path = "@osqp-matlab_SOURCE_DIR@";
+unittest_dir = fullfile(osqp_src_path, 'unittests');
+suiteFolder = TestSuite.fromFolder(unittest_dir);
+
+% Exclude tests that contain codegen in the name
+suiteNoCodegen = selectIf(suiteFolder,~HasName(ContainsSubstring('codegen','IgnoringCase',true)));
+
+% Run all suite
+result = run(suiteNoCodegen);
+
+% Print test results
+disp(table(result))
+
+% Return error code if test failed
+assertSuccess(result)


### PR DESCRIPTION
Adding a CI now that MATLAB is available on GitHub Actions to avoid problems such as https://github.com/ami-iit/osqp-matlab-cmake-buildsystem/issues/5 in the future.

Just adding the tests reproduced the problem experienced by @HosameldinMohamed in https://github.com/ami-iit/osqp-matlab-cmake-buildsystem/issues/5 (see tests failing in https://github.com/ami-iit/osqp-matlab-cmake-buildsystem/actions/runs/1915933780 with "double free" error), so the used osqp commit has been updated to point to the newest commit from https://github.com/osqp/osqp-matlab/pull/34 .

We also bumped the version to 0.6.2.2 to be ready to do a release once this is merged.